### PR TITLE
Add isort to check pipeline

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -36,3 +36,6 @@ jobs:
 
       - name: Check formatting with black
         run: poetry run black --check --diff --color .
+
+      - name: Check import sorting with isort
+        run: poetry run isort --check --diff --color .

--- a/cli.py
+++ b/cli.py
@@ -1,4 +1,5 @@
 import argparse
+
 import shtab
 
 

--- a/description_parser.py
+++ b/description_parser.py
@@ -1,7 +1,6 @@
 import re
 
 import constants
-
 from utils import Utils
 
 INTERPUNCT = "\u00b7"

--- a/music_tags.py
+++ b/music_tags.py
@@ -6,7 +6,6 @@ from simple_term_menu import TerminalMenu  # type: ignore
 
 import colors
 import constants
-
 from utils import Utils
 
 Tags = dict[str, list[str]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,10 @@ pythonPlatform = "Linux"
 [tool.black]
 line-length = 120
 
+[tool.isort]
+profile = "black"
+line_length = 120
+
 [tool.poetry]
 name = "retag_opus"
 version = "0.1.0"

--- a/retag
+++ b/retag
@@ -9,15 +9,15 @@ __author__ = "Simon Bengtsson"
 __version__ = "0.2.0"
 __license__ = "GPLv3"
 
-from mutagen.oggopus import OggOpus  # type: ignore
-from colorama import Fore, init  # type: ignore
 from pathlib import Path
+
+from colorama import Fore, init  # type: ignore
+from mutagen.oggopus import OggOpus  # type: ignore
 from simple_term_menu import TerminalMenu  # type: ignore
 
-from cli import Cli
 import colors
 import constants
-
+from cli import Cli
 from description_parser import DescriptionParser
 from music_tags import MusicTags
 from tags_parser import TagsParser

--- a/tags_parser.py
+++ b/tags_parser.py
@@ -1,9 +1,7 @@
 import re
-
-from typing import List, Dict
+from typing import Dict, List
 
 import constants
-
 from utils import Utils
 
 INTERPUNCT = "\u00b7"

--- a/utils.py
+++ b/utils.py
@@ -1,10 +1,10 @@
 import re
 import sys
+from pathlib import Path
+from typing import List
 
 from colorama import Fore
-from pathlib import Path
 from simple_term_menu import TerminalMenu  # type: ignore
-from typing import List
 
 import constants
 


### PR DESCRIPTION
This PR adds isort checking of new PRs. Default settings are used, plus compatibility with black and line length of 120. Imports are also sorted according to the prescription.