### PR TITLE
Remove usage of sys.exit in favor of exceptions

### DIFF
--- a/retag_opus/app.py
+++ b/retag_opus/app.py
@@ -14,6 +14,7 @@ from simple_term_menu import TerminalMenu
 from retag_opus import colors, constants
 from retag_opus.cli import Cli
 from retag_opus.description_parser import DescriptionParser
+from retag_opus.exceptions import UserExitException
 from retag_opus.music_tags import MusicTags
 from retag_opus.tags_parser import TagsParser
 from retag_opus.utils import Utils
@@ -85,7 +86,11 @@ def run() -> int:
                 break
 
             # 4. For each field, if there are conflicts, ask user input
-            tags.adjust_metadata()
+            try:
+                tags.adjust_metadata()
+            except UserExitException as e:
+                print(f"RetagOpus exited successfully: {e}")
+                return 0
 
             # 4.5 Get rid of shady tags
             tags.prune_final_metadata()
@@ -122,8 +127,8 @@ def run() -> int:
 
                 match action:
                     case "[q] quit":
-                        print(Fore.YELLOW + "Skipping this and all later songs")
-                        Utils().exit_now()
+                        print("RetagOpus exited successfully: Skipping this and all later songs")
+                        return 0
                     case "[s] save":
                         for tag, data in tags.resolved.items():
                             if data == ["[Removed]"]:

--- a/retag_opus/exceptions.py
+++ b/retag_opus/exceptions.py
@@ -1,0 +1,9 @@
+"""
+This file holds custom exceptions for RetagOpus
+"""
+
+
+class UserExitException(Exception):
+    """
+    Raised when the user has made a choice to exit the app
+    """

--- a/retag_opus/music_tags.py
+++ b/retag_opus/music_tags.py
@@ -5,6 +5,7 @@ from mutagen.oggopus import OggOpus
 from simple_term_menu import TerminalMenu
 
 from retag_opus import colors, constants
+from retag_opus.exceptions import UserExitException
 from retag_opus.utils import Utils
 
 Tags = dict[str, list[str]]
@@ -262,8 +263,7 @@ class MusicTags:
                     choice = candidate_menu.show()
 
                     if choice is None:
-                        print(Fore.YELLOW + "Skipping this and all later songs")
-                        Utils().exit_now()
+                        raise UserExitException("Skipping this and all later songs")
                     elif isinstance(choice, tuple):
                         continue
 
@@ -339,8 +339,7 @@ class MusicTags:
                                 self.resolved[field] = from_desc_value
 
                         case "Quit":
-                            print(Fore.YELLOW + "Skipping this and all later songs")
-                            Utils().exit_now()
+                            raise UserExitException("Skipping this and all later songs")
 
         all_artists = self.get_field("artist")
         resolved_artist = self.resolved.get("artist")


### PR DESCRIPTION
All usages of sys.exit() has been removed, except for the one in __main__. Exceptions are raised instead, and caught in app.run. User exits straight from app.run are handled by printing a message and returning 0.

This closes #6 