### PR TITLE
Add tests and CI test job

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,3 +42,27 @@ jobs:
 
       - name: Check type annotation with mypy
         run: poetry run mypy --strict .
+
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Poetry
+        run: pipx install poetry
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+          cache: "poetry"
+
+      - name: Install dependencies
+        run: |
+          poetry env use $(which python3.10)
+          poetry install
+
+      - name: Run pytest
+        run: poetry run pytest --cov

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ pitchfork.csv
 todo-retag
 __pycache__
 dist
+.hypothesis

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ todo-retag
 __pycache__
 dist
 .hypothesis
+.coverage

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,4 +1,26 @@
 [[package]]
+name = "atomicwrites"
+version = "1.4.1"
+description = "Atomic file writes."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "attrs"
+version = "22.1.0"
+description = "Classes Without Boilerplate"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.extras]
+tests_no_zope = ["cloudpickle", "pytest-mypy-plugins", "mypy (>=0.900,!=0.940)", "pytest (>=4.3.0)", "pympler", "hypothesis", "coverage[toml] (>=5.0.2)"]
+tests = ["cloudpickle", "zope.interface", "pytest-mypy-plugins", "mypy (>=0.900,!=0.940)", "pytest (>=4.3.0)", "pympler", "hypothesis", "coverage[toml] (>=5.0.2)"]
+docs = ["sphinx-notfound-page", "zope.interface", "sphinx", "furo"]
+dev = ["cloudpickle", "pre-commit", "sphinx-notfound-page", "sphinx", "furo", "zope.interface", "pytest-mypy-plugins", "mypy (>=0.900,!=0.940)", "pytest (>=4.3.0)", "pympler", "hypothesis", "coverage[toml] (>=5.0.2)"]
+
+[[package]]
 name = "black"
 version = "22.3.0"
 description = "The uncompromising code formatter."
@@ -39,6 +61,20 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "coverage"
+version = "6.4.4"
+description = "Code coverage measurement for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.11.0a6\" and extra == \"toml\""}
+
+[package.extras]
+toml = ["tomli"]
+
+[[package]]
 name = "flake8"
 version = "4.0.1"
 description = "the modular source code checker: pep8 pyflakes and co"
@@ -62,6 +98,14 @@ python-versions = "*"
 [package.dependencies]
 flake8 = ">=3"
 pydocstyle = ">=2.1"
+
+[[package]]
+name = "iniconfig"
+version = "1.1.1"
+description = "iniconfig: brain-dead simple config-ini parsing"
+category = "dev"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "isort"
@@ -120,6 +164,17 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "packaging"
+version = "21.3"
+description = "Core utilities for Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
+
+[[package]]
 name = "pathspec"
 version = "0.9.0"
 description = "Utility library for gitignore style pattern matching of file paths."
@@ -138,6 +193,26 @@ python-versions = ">=3.7"
 [package.extras]
 docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)", "sphinx (>=4)"]
 test = ["appdirs (==1.4.4)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)", "pytest (>=6)"]
+
+[[package]]
+name = "pluggy"
+version = "1.0.0"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "py"
+version = "1.11.0"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "pycodestyle"
@@ -168,6 +243,53 @@ description = "passive checker of Python programs"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pyparsing"
+version = "3.0.9"
+description = "pyparsing module - Classes and methods to define and execute parsing grammars"
+category = "dev"
+optional = false
+python-versions = ">=3.6.8"
+
+[package.extras]
+diagrams = ["railroad-diagrams", "jinja2"]
+
+[[package]]
+name = "pytest"
+version = "7.1.2"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
+attrs = ">=19.2.0"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<2.0"
+py = ">=1.8.2"
+tomli = ">=1.0.0"
+
+[package.extras]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
+
+[[package]]
+name = "pytest-cov"
+version = "3.0.0"
+description = "Pytest plugin for measuring coverage."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+coverage = {version = ">=5.2.1", extras = ["toml"]}
+pytest = ">=4.6"
+
+[package.extras]
+testing = ["virtualenv", "pytest-xdist", "six", "process-tests", "hunter", "fields"]
 
 [[package]]
 name = "shtab"
@@ -212,9 +334,11 @@ python-versions = ">=3.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "3d6da780ba53273e0157735d9567fedf8024a1ff6528b84b49cd428571ec1c52"
+content-hash = "5b48fc7cfc3788bc4f0354c3cd7c1fb4b3003880c656a7d213aefa47d80e4372"
 
 [metadata.files]
+atomicwrites = []
+attrs = []
 black = [
     {file = "black-22.3.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2497f9c2386572e28921fa8bec7be3e51de6801f7459dffd6e62492531c47e09"},
     {file = "black-22.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5795a0375eb87bfe902e80e0c8cfaedf8af4d49694d69161e5bd3206c18618bb"},
@@ -248,11 +372,16 @@ colorama = [
     {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
     {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
 ]
+coverage = []
 flake8 = [
     {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
     {file = "flake8-4.0.1.tar.gz", hash = "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"},
 ]
 flake8-docstrings = []
+iniconfig = [
+    {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
+    {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
+]
 isort = [
     {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
     {file = "isort-5.10.1.tar.gz", hash = "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"},
@@ -294,6 +423,10 @@ mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
+packaging = [
+    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
+    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
+]
 pathspec = [
     {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
     {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
@@ -301,6 +434,14 @@ pathspec = [
 platformdirs = [
     {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
     {file = "platformdirs-2.5.2.tar.gz", hash = "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"},
+]
+pluggy = [
+    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
+    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+]
+py = [
+    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
+    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
 ]
 pycodestyle = [
     {file = "pycodestyle-2.8.0-py2.py3-none-any.whl", hash = "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20"},
@@ -311,6 +452,15 @@ pyflakes = [
     {file = "pyflakes-2.4.0-py2.py3-none-any.whl", hash = "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"},
     {file = "pyflakes-2.4.0.tar.gz", hash = "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c"},
 ]
+pyparsing = [
+    {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
+    {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
+]
+pytest = [
+    {file = "pytest-7.1.2-py3-none-any.whl", hash = "sha256:13d0e3ccfc2b6e26be000cb6568c832ba67ba32e719443bfe725814d3c42433c"},
+    {file = "pytest-7.1.2.tar.gz", hash = "sha256:a06a0425453864a270bc45e71f783330a7428defb4230fb5e6a731fde06ecd45"},
+]
+pytest-cov = []
 shtab = [
     {file = "shtab-1.5.5-py2.py3-none-any.whl", hash = "sha256:f4bf7cc122fb434cb65b96db7e3adcf3b5258846e906e60c48b3725d2965c6b5"},
     {file = "shtab-1.5.5.tar.gz", hash = "sha256:f90a6ce64b821002d5881b6212992a27ab40c3bab36aabca8de118b0b78f61f6"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,8 @@ isort = "^5.10.1"
 mypy = "^0.960"
 flake8 = "^4.0.1"
 flake8-docstrings = "^1.6.0"
+coverage = "^6.4.4"
+pytest-cov = "^3.0.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,11 @@
+[tool.coverage.run]
+branch = true
+source = [ "./retag_opus/" ]
+
+[tool.coverage.report]
+show_missing = true
+fail_under = 7
+
 [tool.pyright]
 pythonVersion = "3.10"
 pythonPlatform = "Linux"

--- a/retag_opus/app.py
+++ b/retag_opus/app.py
@@ -44,7 +44,7 @@ def run() -> int:
             redo = False
             # Print info about file and progress
             print(Fore.BLUE + f"\nSong {idx + 1} of {len(all_files)}")
-            print(Fore.BLUE + f"----- File: {file_name} -----")
+            print(Fore.BLUE + f"----- Song: {file_name} -----")
 
             # 1. Read the data and make basic improvements
             old_metadata: OggOpus = OggOpus(file_path)

--- a/retag_opus/constants.py
+++ b/retag_opus/constants.py
@@ -19,12 +19,13 @@ class ParsingReference(TypedDict):
 
 
 tag_parse_patterns: dict[str, str] = {
-    "featuring": r"(.*?)\s*[\(\[\ ][fF]eat.?\s+(.+)[\)\]]*\s*(.*)",
-    "remaster": r"(.*?)\s*\((\d{0,4}\s*[rR]emaster.*)\)\s*(.*)",
-    "remaster2": r"(.*?)\s*-\s*(\d{0,4}\s*[Rr]emaster.*)(.*)",
-    "live": r"(.*?)\s*[\(\[]([lL]ive.*)[\)\]]\s*(.*)",
-    "instrumental": r"(.*?)\s*[\(\[]([iI]nstrumental.*)[\)\]]\s*(.*)",
-    "remix": r"(.*?)\s*\((.*[rR]emix.*)\)\s*(.*)",
+    "featuring": r"(?i)(.*?)\s*[\(\[\ ]feat.?\s+(.+)[\)\]]*\s*(.*)",
+    "remaster": r"(?i)(.*?)\s*\((\d{0,4}\s*remaster.*)\)\s*(.*)",
+    "remaster2": r"(.*?)\s*-\s*(\d{0,4}.*remaster.*)(.*)",
+    "live": r"(?i)(.*?)\s*[\(\[](live.*)[\)\]]\s*(.*)",
+    "instrumental": r"(?i)(.*?)\s*[\(\[](instrumental.*)[\)\]]\s*(.*)",
+    "remix": r"(?i)(.*?)\s*\((.*remix.*)\)\s*(.*)",
+    "remix2": r"(?i)(.*?)\s*-\s*(.*remix.*)\s*(.*)",
 }
 
 all_tags: dict[str, ParsingReference] = {

--- a/retag_opus/constants.py
+++ b/retag_opus/constants.py
@@ -19,7 +19,7 @@ class ParsingReference(TypedDict):
 
 
 tag_parse_patterns: dict[str, str] = {
-    "featuring": r"(?i)(.*?)\s*[\(\[\ ]feat.?\s+(.+)[\)\]]*\s*(.*)",
+    "featuring": r"(?i)(.*?)\s*[\(\[\ ](?:feat|ft|featuring).?\s+(.+)[\)\]]*\s*(.*)",
     "remaster": r"(?i)(.*?)\s*\((\d{0,4}\s*remaster.*)\)\s*(.*)",
     "remaster2": r"(.*?)\s*-\s*(\d{0,4}.*remaster.*)(.*)",
     "live": r"(?i)(.*?)\s*[\(\[](live.*)[\)\]]\s*(.*)",

--- a/retag_opus/utils.py
+++ b/retag_opus/utils.py
@@ -34,7 +34,9 @@ class Utils:
     @staticmethod
     def split_tag(input: str) -> List[str]:
         """Split the provided tag by pre-defined delimeters."""
-        return re.split(", | and | & |; ", input)
+        split_tags = re.split(", | and | & |; ", input)
+        split_pruned_tags = [t.strip() for t in split_tags]
+        return split_pruned_tags
 
     @staticmethod
     def file_path_to_song_data(file_path: Path) -> str:

--- a/retag_opus/utils.py
+++ b/retag_opus/utils.py
@@ -45,19 +45,23 @@ class Utils:
         Produce a string with song title and artist on a readable format
         from the name of the file being worked with.
         """
-        file_name = str(file_path)
-        basename = re.match(".*/(.*)", file_name)
-        if basename:
-            match = basename.groups()[0]
-            file_name = match
-            name_playlist = re.match("<(.*)> - <(.*)> - <(.*)> - <(.*)>.opus", file_name)
-            name_single = re.match("<(.*)> - <(.*)>.opus", file_name)
-            if name_playlist:
-                file_name = name_playlist.groups()[1] + " - " + name_playlist.groups()[2]
-            elif name_single:
-                file_name = name_single.groups()[0] + " - " + name_single.groups()[1]
-
-        return file_name
+        text_to_print = str(file_path)
+        basename_match = re.match(r"(.+/)*(.*).opus", text_to_print)
+        print(file_path)
+        if basename_match:
+            basename = basename_match.groups()[1]
+            print(basename)
+            text_to_print = basename
+            playlist_match = re.match(r"<(.*)> - <(.*?)(?: - Topic)*> - <(.*)> - <(.*)>", text_to_print)
+            artist_title_match = re.match("<(.*?)(?: - Topic)*> - <(.*)>", text_to_print)
+            title_only_match = re.match("<(.*)>", text_to_print)
+            if playlist_match:
+                text_to_print = playlist_match.groups()[1] + " - " + playlist_match.groups()[2]
+            elif artist_title_match:
+                text_to_print = artist_title_match.groups()[0] + " - " + artist_title_match.groups()[1]
+            elif title_only_match:
+                text_to_print = title_only_match.groups()[0]
+        return text_to_print
 
     @staticmethod
     def select_single_tag(candidates: list[str]) -> list[str]:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Module for testing the retag_opus module."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,20 +8,20 @@ from retag_opus.utils import Utils
 class TestUtils(unittest.TestCase):
     """Test the Utils class."""
 
-    def test_remove_duplicates(self):
+    def test_remove_duplicates(self) -> None:
         """Test that duplicates are removed."""
         duplicates = ["alpha", "beta", "alpha"]
         unduplicated = Utils.remove_duplicates(duplicates)
         self.assertEqual(2, len(unduplicated))
         self.assertListEqual(["alpha", "beta"], unduplicated)
 
-    def test_prune_title_remove_whitespace(self):
+    def test_prune_title_remove_whitespace(self) -> None:
         """Test that title has surrounding whitespace removed."""
         unpruned_title = " title of the song "
         pruned_title = Utils.prune_title(unpruned_title)
         self.assertEqual("title of the song", pruned_title)
 
-    def test_prune_live_from_title(self):
+    def test_prune_live_from_title(self) -> None:
         """Test that live version information is pruned from title."""
         unpruned_title_1 = "A song (live)"
         unpruned_title_2 = "A song [live]"
@@ -38,7 +38,7 @@ class TestUtils(unittest.TestCase):
         self.assertEqual("A song", Utils.prune_title(unpruned_title_6))
         self.assertEqual("Spring (för livet)", Utils.prune_title(unpruned_title_7))
 
-    def test_prune_remix_from_title(self):
+    def test_prune_remix_from_title(self) -> None:
         """Test that remix version information is pruned from title."""
         unpruned_title_1 = "A song (person's remix)"
         unpruned_title_2 = "A song (person's Remix)"
@@ -53,7 +53,7 @@ class TestUtils(unittest.TestCase):
         self.assertEqual("3 Gerald remix", Utils.prune_title(unpruned_title_5))
         self.assertEqual("Summers Gonna Hurt You", Utils.prune_title(unpruned_title_6))
 
-    def test_prune_remaster_from_title(self):
+    def test_prune_remaster_from_title(self) -> None:
         """Test that remix version information is pruned from title."""
         unpruned_title_1 = "A song (1934 remaster)"
         unpruned_title_2 = "A song (1934 remaster)"
@@ -74,7 +74,7 @@ class TestUtils(unittest.TestCase):
         self.assertEqual("A song", Utils.prune_title(unpruned_title_7))
         self.assertEqual("A song", Utils.prune_title(unpruned_title_8))
 
-    def test_prune_instrumental_from_title(self):
+    def test_prune_instrumental_from_title(self) -> None:
         """Test that remix version information is pruned from title."""
         unpruned_title_1 = "A song (instrumental)"
         unpruned_title_2 = "A song (Instrumental)"
@@ -85,7 +85,7 @@ class TestUtils(unittest.TestCase):
         self.assertEqual("A song", Utils.prune_title(unpruned_title_3))
         self.assertEqual("A song", Utils.prune_title(unpruned_title_4))
 
-    def test_prune_featuring_from_title(self):
+    def test_prune_featuring_from_title(self) -> None:
         """Test that remix version information is pruned from title."""
         unpruned_title_1 = "A song (featuring artist)"
         unpruned_title_2 = "A song (Featuring artist)"
@@ -117,7 +117,7 @@ class TestUtils(unittest.TestCase):
         self.assertEqual("A song", Utils.prune_title(unpruned_title_13))
         self.assertEqual("A song", Utils.prune_title(unpruned_title_14))
 
-    def test_split_tags(self):
+    def test_split_tags(self) -> None:
         """Test that tags are split at given characters and pruned."""
         unsplit_tag_1 = "an artist and another artist"
         unsplit_tag_2 = "an artist, another artist & a third artist"
@@ -133,7 +133,7 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(["an artist", "another artist"], Utils.split_tag(unsplit_tag_5))
         self.assertEqual(["an artist", "another artist"], Utils.split_tag(unsplit_tag_6))
 
-    def test_file_path_to_song_title(self):
+    def test_file_path_to_song_title(self) -> None:
         """Test that a file path can be converted to a song title."""
         song = Path("<artist> - <title>.opus")
         song_nested = Path("path/to/<artist> - <title>.opus")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,85 @@
+"""Tests for utils.py."""
+import unittest
+
+from retag_opus.utils import Utils
+
+
+class TestUtils(unittest.TestCase):
+    """Test the Utils class."""
+
+    def test_remove_duplicates(self):
+        """Test that duplicates are removed."""
+        duplicates = ["alpha", "beta", "alpha"]
+        unduplicated = Utils.remove_duplicates(duplicates)
+        self.assertEqual(2, len(unduplicated))
+        self.assertListEqual(["alpha", "beta"], unduplicated)
+
+    def test_prune_title_remove_whitespace(self):
+        """Test that title has surrounding whitespace removed."""
+        unpruned_title = " title of the song "
+        pruned_title = Utils.prune_title(unpruned_title)
+        self.assertEqual("title of the song", pruned_title)
+
+    def test_prune_live_from_title(self):
+        """Test that live version information is pruned from title."""
+        unpruned_title_1 = "A song (live)"
+        unpruned_title_2 = "A song [live]"
+        unpruned_title_3 = "A song (Live)"
+        unpruned_title_4 = "A song (LivE)"
+        unpruned_title_5 = "A song (live 1998)"
+        unpruned_title_6 = "A song (live cut)"
+        unpruned_title_7 = "Spring (för livet)"
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_1))
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_2))
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_3))
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_4))
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_5))
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_6))
+        self.assertEqual("Spring (för livet)", Utils.prune_title(unpruned_title_7))
+
+    def test_prune_remix_from_title(self):
+        """Test that remix version information is pruned from title."""
+        unpruned_title_1 = "A song (person's remix)"
+        unpruned_title_2 = "A song (person's Remix)"
+        unpruned_title_3 = "A song (person's RemIx)"
+        unpruned_title_4 = "A song - person's RemIx"
+        unpruned_title_5 = "3 Gerald remix"
+        unpruned_title_6 = "Summers Gonna Hurt You (Diplo 2010 Remix)"
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_1))
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_2))
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_3))
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_4))
+        self.assertEqual("3 Gerald remix", Utils.prune_title(unpruned_title_5))
+        self.assertEqual("Summers Gonna Hurt You", Utils.prune_title(unpruned_title_6))
+
+    def test_prune_remaster_from_title(self):
+        """Test that remix version information is pruned from title."""
+        unpruned_title_1 = "A song (1934 remaster)"
+        unpruned_title_2 = "A song (1934 remaster)"
+        unpruned_title_3 = "A song (1934 Remaster)"
+        unpruned_title_4 = "A song (remaster)"
+        unpruned_title_5 = "A song (remastered)"
+        unpruned_title_6 = "A song - 1992 digital remaster"
+        unpruned_title_7 = "A song - 1992 remaster"
+        unpruned_title_8 = "A song - 1992 remastered"
+        unpruned_title_1 = "A song (remastered 1934)"
+        unpruned_title_7 = "A song - remastered 1992"
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_1))
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_2))
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_3))
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_4))
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_5))
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_6))
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_7))
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_8))
+
+    def test_prune_instrumental_from_title(self):
+        """Test that remix version information is pruned from title."""
+        unpruned_title_1 = "A song (instrumental)"
+        unpruned_title_2 = "A song (Instrumental)"
+        unpruned_title_3 = "A song (InstrumEntal)"
+        unpruned_title_4 = "A song [instrumental]"
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_1))
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_2))
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_3))
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_4))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 """Tests for utils.py."""
 import unittest
+from pathlib import Path
 
 from retag_opus.utils import Utils
 
@@ -131,3 +132,21 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(["an artist", "another artist", "a third artist"], Utils.split_tag(unsplit_tag_4))
         self.assertEqual(["an artist", "another artist"], Utils.split_tag(unsplit_tag_5))
         self.assertEqual(["an artist", "another artist"], Utils.split_tag(unsplit_tag_6))
+
+    def test_file_path_to_song_title(self):
+        """Test that a file path can be converted to a song title."""
+        song = Path("<artist> - <title>.opus")
+        song_nested = Path("path/to/<artist> - <title>.opus")
+        song_topic = Path("<artist - Topic> - <title>.opus")
+        playlist = Path("<01> - <Artist - Topic> - <Title of Song> - <zTByLCLu6NI>.opus")
+        playlist_nested = Path("path/to/<01> - <Artist - Topic> - <Title of Song> - <zTByLCLu6NI>.opus")
+        only_title = Path("<a song title>.opus")
+        no_angle_brackets = Path("a song title.opus")
+
+        self.assertEqual("artist - title", Utils.file_path_to_song_data(song))
+        self.assertEqual("artist - title", Utils.file_path_to_song_data(song_nested))
+        self.assertEqual("artist - title", Utils.file_path_to_song_data(song_topic))
+        self.assertEqual("Artist - Title of Song", Utils.file_path_to_song_data(playlist))
+        self.assertEqual("Artist - Title of Song", Utils.file_path_to_song_data(playlist_nested))
+        self.assertEqual("a song title", Utils.file_path_to_song_data(only_title))
+        self.assertEqual("a song title", Utils.file_path_to_song_data(no_angle_brackets))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -83,3 +83,51 @@ class TestUtils(unittest.TestCase):
         self.assertEqual("A song", Utils.prune_title(unpruned_title_2))
         self.assertEqual("A song", Utils.prune_title(unpruned_title_3))
         self.assertEqual("A song", Utils.prune_title(unpruned_title_4))
+
+    def test_prune_featuring_from_title(self):
+        """Test that remix version information is pruned from title."""
+        unpruned_title_1 = "A song (featuring artist)"
+        unpruned_title_2 = "A song (Featuring artist)"
+        unpruned_title_3 = "A song (FeatUring artist)"
+        unpruned_title_4 = "A song [featuring artist]"
+        unpruned_title_5 = "A song (feat. artist)"
+        unpruned_title_6 = "A song (ft. artist)"
+        unpruned_title_7 = "A song feat. artist"
+        unpruned_title_8 = "A song ft. artist"
+        unpruned_title_9 = "A song feat. artist and second artist"
+        unpruned_title_10 = "A song ft. artist"
+        unpruned_title_11 = "A song (ft. another artist & a, third)"
+        unpruned_title_12 = "A song ft. an artist, another artist"
+        unpruned_title_13 = "A song Ft an artist"
+        unpruned_title_14 = "A song(ft. an artist)"
+
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_1))
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_2))
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_3))
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_4))
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_5))
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_6))
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_7))
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_8))
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_9))
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_10))
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_11))
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_12))
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_13))
+        self.assertEqual("A song", Utils.prune_title(unpruned_title_14))
+
+    def test_split_tags(self):
+        """Test that tags are split at given characters and pruned."""
+        unsplit_tag_1 = "an artist and another artist"
+        unsplit_tag_2 = "an artist, another artist & a third artist"
+        unsplit_tag_3 = "an artist, another artist and a third artist"
+        unsplit_tag_4 = "an artist and  another artist and a third artist"
+        unsplit_tag_5 = "an artist; another artist"
+        unsplit_tag_6 = "an artist ; another artist"
+
+        self.assertEqual(["an artist", "another artist"], Utils.split_tag(unsplit_tag_1))
+        self.assertEqual(["an artist", "another artist", "a third artist"], Utils.split_tag(unsplit_tag_2))
+        self.assertEqual(["an artist", "another artist", "a third artist"], Utils.split_tag(unsplit_tag_3))
+        self.assertEqual(["an artist", "another artist", "a third artist"], Utils.split_tag(unsplit_tag_4))
+        self.assertEqual(["an artist", "another artist"], Utils.split_tag(unsplit_tag_5))
+        self.assertEqual(["an artist", "another artist"], Utils.split_tag(unsplit_tag_6))


### PR DESCRIPTION
Some tests for the Utils class have been added, as well as a CI pipeline job that runs pytest with the --cov flag. The MR contains the following commits:

- Make regex case insensitve and fix remaster
- Add tests for prune title and remove duplicates
- Prune split tags and fix featuring regex
- Add tests for split tags and prune title
- Improve file name artist/title extraction
- Test file name artist/title extraction
- Add dev dependency on coverage and pytest-cov
- Add test and coverage to CI pipeline
