### PR TITLE
Add a workflow status badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,8 @@ removed.
 The project is still under development. The most common tags can be
 parsed but there are many more which will just be ignored. Work needs to
 be done in usability.
+
+Latest workflow status:
+
+![Check pipeline status badge](https://github.com/gevhaz/Retag-Opus/actions/workflows/check.yml/badge.svg)
+![Deploy pipeline status badge](https://github.com/gevhaz/Retag-Opus/actions/workflows/deploy.yml/badge.svg)


### PR DESCRIPTION
Status badges have been added to the readme for the two workflows in the repo (check and deploy). They show whether the latest run of these pipelines passed for failed.