### PR TITLE
Default to value got from original if no original

### DIFF
--- a/retag_opus/music_tags.py
+++ b/retag_opus/music_tags.py
@@ -459,6 +459,8 @@ class MusicTags:
             if not old_value and len(all_values) > 0 and tag_name != "albumartist":
                 if len(yt_value) > 0:
                     self.resolved[tag_name] = yt_value
+                elif len(from_tags_value) > 0:
+                    self.resolved[tag_name] = from_tags_value
                 elif len(from_desc_value) > 0:
                     self.resolved[tag_name] = from_desc_value
                 else:

--- a/tests/test_music_tags.py
+++ b/tests/test_music_tags.py
@@ -1375,7 +1375,7 @@ class TestMusicTags(unittest.TestCase):
 
         tags.fromtags = {"artist": ["artist 1"]}
         tags.resolve_metadata()
-        self.assertEqual({}, tags.resolved)
+        self.assertEqual({"artist": ["artist 1"], "albumartist": ["artist 1"]}, tags.resolved)
 
     @patch("retag_opus.music_tags.MusicTags.determine_album_artist")
     def test_resolve_metadata_equal_when_stripped(self, mock_album_artist: MagicMock) -> None:


### PR DESCRIPTION
Default to value parsed from original tags if no original tags exists. This sounds like an oxymoron, but it works when you parse the value for e.g. the version tag from the title tag.
