### PR TITLE
Add ability to configure tags to delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,32 @@ As you can see, you can remove tags, which will make them print
 "[Removed]" in red text. In the actual song metadata, they will just be
 removed.
 
+## Configuration
+
+You can configure tags that should be deleted. There are two ways you can
+configure these. You can either say an exact tag name that should be deleted –
+that is, the name of the tag itself, not its value. You can also specify a regex
+that, if fully matching any value in a tag, will result in that tag being
+deleted.
+
+You specify this information in the Retag-Opus configuration file which is
+`retag.toml` in your `XDG_CONFIG_HOME` directory, so usually
+`~/.config/retag.toml`. Here is an example:
+
+```toml
+tags_to_delete = [
+  "language",
+]
+strings_to_delete_tags_based_on = [
+  "delete_exactly_this",
+  ".*delete_any_partial_match.*",
+]
+```
+
+This will delete the `language` tag, any tag containing the exact value
+`delete_exactly_this` but not `delete_exactly_this_other_thing`, and also any
+tag that matches the last regex, such as `test_delete_any_partial_match_test`.
+
 # Project status
 
 The project is still under development. The most common tags can be

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ source = [ "./retag_opus/" ]
 
 [tool.coverage.report]
 show_missing = true
-fail_under = 96.17
+fail_under = 95.80
 exclude_lines = [
     'import sys',
     'from retag_opus import app',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ source = [ "./retag_opus/" ]
 
 [tool.coverage.report]
 show_missing = true
-fail_under = 95.80
+fail_under = 95.73
 exclude_lines = [
     'import sys',
     'from retag_opus import app',

--- a/retag_opus/app.py
+++ b/retag_opus/app.py
@@ -102,6 +102,11 @@ def run(argv: Sequence[str] | None = None) -> int:
                 new_tags_parser.parse_tags()
                 tags.fromdesc = new_tags_parser.tags
 
+            # 4.5 Get rid of shady tags
+            tags_to_delete = config.get("tags_to_delete", [])
+            strings_to_delete_tags_based_on = config.get("strings_to_delete_tags_based_on", [])
+            tags.prune_resolved_tags(tags_to_delete, strings_to_delete_tags_based_on)
+
             if not tags.check_any_new_data_exists() and not args.manual_album:
                 print(Fore.YELLOW + "No new data exists. Skipping song." + Fore.RESET)
                 break
@@ -112,11 +117,6 @@ def run(argv: Sequence[str] | None = None) -> int:
             except UserExitException as e:
                 print(f"RetagOpus exited successfully: {e}")
                 return 0
-
-            # 4.5 Get rid of shady tags
-            tags_to_delete = config.get("tags_to_delete", [])
-            strings_to_delete_tags_based_on = config.get("strings_to_delete_tags_based_on", [])
-            tags.prune_resolved_tags(tags_to_delete, strings_to_delete_tags_based_on)
 
             # 5. Show user final result and ask if it should be saved or
             # retried, or song skipped
@@ -152,11 +152,9 @@ def run(argv: Sequence[str] | None = None) -> int:
                     case "[s] save":
                         for tag, data in tags.resolved.items():
                             if data == REMOVED_TAG:
-                                old_tags.pop(tag, None)
+                                old_metadata.pop(tag, None)  # type: ignore
                             else:
-                                old_tags[tag] = data
-                        for key, val in old_tags.items():
-                            old_metadata[key] = val
+                                old_metadata[tag] = data
                         old_metadata.save()
                         print(Fore.GREEN + f"Metadata saved for file: {file_name}")
                     case "[r] reset":

--- a/retag_opus/music_tags.py
+++ b/retag_opus/music_tags.py
@@ -251,7 +251,8 @@ class MusicTags:
     def add_source_tag(self) -> None:
         """Add a comment tag with the value 'youtube-dl'."""
         if any("youtube" in item for item in self.original.get("purl", [])):
-            self.resolved["comment"] = self.original.get("comment", []) + ["youtube-dl"]
+            if "youtube-dl" not in self.original.get("comment", []):
+                self.resolved["comment"] = self.original.get("comment", []) + ["youtube-dl"]
 
     def get_field(self, field: str, only_new: bool = False) -> list[str]:
         """Get values for field from all sources.

--- a/retag_opus/music_tags.py
+++ b/retag_opus/music_tags.py
@@ -36,8 +36,8 @@ class MusicTags:
         self.fromdesc: Tags = {}
         self.resolved: Tags = {}
 
-    @staticmethod
     def print_metadata_key(
+        self,
         key_type: str,
         key: str,
         key_col: str,
@@ -51,6 +51,8 @@ class MusicTags:
         :param data: The tags from which to get the given key.
         """
         value = constants.SEP.join(data.get(key, ["Not found"])).replace(" ", constants.SPACE)
+        if self.resolved.get(key) == ["[Removed]"]:
+            key_type = f"{key_type} (Removed)"
         key_col = key_col if data.get(key) else Fore.BLACK
         print("  " + key_type + ": " + key_col + value + Fore.RESET)
 
@@ -64,9 +66,9 @@ class MusicTags:
             print("  Performers:")
             for tag_id, tag_data in self.performer_patterns.items():
                 if tag_id in metadata and metadata[tag_id] is not None:
-                    MusicTags.print_metadata_key(tag_data["print"], tag_id, col, metadata)
+                    self.print_metadata_key(tag_data["print"], tag_id, col, metadata)
         for tag_id, tag_data in self.base_patterns.items():
-            MusicTags.print_metadata_key(tag_data["print"], tag_id, col, metadata)
+            self.print_metadata_key(tag_data["print"], tag_id, col, metadata)
         print("")
 
     def get_tag_data(self, tag_id: str) -> list[str]:
@@ -179,7 +181,7 @@ class MusicTags:
                 resolved_tag = self.resolved.get(tag, [])
                 joined_tag_items = " | ".join(resolved_tag).replace("\n", " ")
                 if resolved_tag == REMOVED_TAG:
-                    self.print_metadata_key(f"- {tag}", tag, Fore.RED, self.resolved)
+                    self.print_metadata_key(f"- {tag}", tag, Fore.RED, self.original)
                 elif resolved_tag != self.original.get(tag):
                     self.print_metadata_key(f"- {tag}", tag, Fore.GREEN, self.resolved)
                 elif len(joined_tag_items) > 200:
@@ -194,7 +196,7 @@ class MusicTags:
                 all_sources_tag = self.get_tag_data(tag_id)
                 # If the user chose to remove a tag that existed before
                 if resolved_tag == REMOVED_TAG:
-                    self.print_metadata_key(tag_data["print"], tag_id, Fore.RED, self.resolved)
+                    self.print_metadata_key(tag_data["print"], tag_id, Fore.RED, self.original)
                 # If the resolved tag differs from the original tag
                 elif resolved_tag != self.original.get(tag_id, []) and self.resolved.get(tag_id) is not None:
                     self.print_metadata_key(tag_data["print"], tag_id, Fore.GREEN, self.resolved)
@@ -207,7 +209,7 @@ class MusicTags:
             resolved_tag = self.resolved.get(tag_id, [])
             all_sources_tag = self.get_tag_data(tag_id)
             if resolved_tag == REMOVED_TAG:
-                self.print_metadata_key(tag_data["print"], tag_id, Fore.RED, self.resolved)
+                self.print_metadata_key(tag_data["print"], tag_id, Fore.RED, self.original)
             elif resolved_tag != self.original.get(tag_id, []) and self.resolved.get(tag_id) is not None:
                 self.print_metadata_key(tag_data["print"], tag_id, Fore.GREEN, self.resolved)
             elif len(all_sources_tag) > 0 and print_all:

--- a/retag_opus/music_tags.py
+++ b/retag_opus/music_tags.py
@@ -235,13 +235,16 @@ class MusicTags:
         if self.original.get("date") and re.match(r"\d\d\d\d\d\d\d\d", self.original["date"][0]):
             self.original.pop("date", None)
 
-    def prune_resolved_tags(self) -> None:
-        """Remove tags that are not useful."""
-        self.resolved["language"] = REMOVED_TAG
-        self.resolved["compatible_brands"] = REMOVED_TAG
-        self.resolved["minor_version"] = REMOVED_TAG
-        self.resolved["major_brand"] = REMOVED_TAG
-        self.resolved["vendor_id"] = REMOVED_TAG
+    def prune_resolved_tags(self, tags_to_delete: list[str], strings_to_delete_tags_based_on: list[str]) -> None:
+        """Remove tags that the user wants removed by default."""
+        for tag in tags_to_delete:
+            if tag in self.original:
+                self.resolved[tag] = REMOVED_TAG
+
+        for tag_id, tag_data in self.original.items():
+            for bad_word in strings_to_delete_tags_based_on:
+                if any(re.fullmatch(bad_word, item) for item in tag_data):
+                    self.resolved[tag_id] = REMOVED_TAG
 
     def add_source_tag(self) -> None:
         """Add a comment tag with the value 'youtube-dl'."""

--- a/retag_opus/music_tags.py
+++ b/retag_opus/music_tags.py
@@ -250,7 +250,8 @@ class MusicTags:
 
     def add_source_tag(self) -> None:
         """Add a comment tag with the value 'youtube-dl'."""
-        self.resolved["comment"] = self.original.get("comment", []) + ["youtube-dl"]
+        if any("youtube" in item for item in self.original.get("purl", [])):
+            self.resolved["comment"] = self.original.get("comment", []) + ["youtube-dl"]
 
     def get_field(self, field: str, only_new: bool = False) -> list[str]:
         """Get values for field from all sources.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -160,7 +160,6 @@ def test_file_with_new_metadata(capsys, music_directory, monkeypatch):
         f"\n-----------------------------------------------"
         "\n  Other tags:"
         f"\n  - synopsis: {Fore.CYAN}[Provided to YouTube by Rich Men's Group Digital Ltd.  Proper Good...]{Fore.RESET}"
-        f"\n  - comment: {Fore.GREEN}youtube-dl{Fore.RESET}"
         f"\n  Title: {Fore.GREEN}Proper Goodbyes{Fore.RESET} | "
         f"{Fore.MAGENTA}Proper Goodbyes (feat. Ben Ivor){Fore.RESET}"
         f"\n  Album: {Fore.MAGENTA}Proper Goodbyes (feat. Ben Ivor){Fore.RESET}"
@@ -223,7 +222,6 @@ def test_file_with_new_metadata_from_many_sources(capsys, music_directory, monke
         f"\n-----------------------------------------------"
         "\n  Other tags:"
         f"\n  - synopsis: {Fore.CYAN}[Provided to YouTube by Rich Men's Group Digital Ltd.  Proper Good...]{Fore.RESET}"
-        f"\n  - comment: {Fore.GREEN}youtube-dl{Fore.RESET}"
         "\n  Title: "
         f"{Fore.YELLOW}Proper Goodbyes{Fore.RESET}"
         f" | {Fore.GREEN}Proper Goodbyes{Fore.RESET}"
@@ -408,6 +406,7 @@ def test_saving(music_directory, monkeypatch, capsys):
     original_metadata = {
         "title": ["Proper Goodbyes (feat. Benny Ivor) (2039 Remaster)"],
         "artist": ["artist 1 and artist 2"],
+        "purl": ["www.youtube.com"],
         "synopsis": [
             "Provided to YouTube by Rich Men's Group Digital Ltd."
             "\n\nProper Goodbyes (feat. Ben Ivor) (2036 Remaster) · The Global · Ben Ivor"
@@ -489,6 +488,7 @@ def test_deleting_tag(music_directory, monkeypatch, capsys):
     original_metadata = {
         "title": ["Proper Goodbyes (feat. Benny Ivor) (2039 Remaster)"],
         "artist": ["artist 1 and artist 2"],
+        "purl": ["www.youtube.com"],
         "synopsis": [
             "Provided to YouTube by Rich Men's Group Digital Ltd."
             "\n\nProper Goodbyes (feat. Ben Ivor) (2036 Remaster) · The Global · Ben Ivor"

--- a/tests/test_music_tags.py
+++ b/tests/test_music_tags.py
@@ -795,6 +795,7 @@ class TestMusicTags(unittest.TestCase):
     def test_add_source_tag(self) -> None:
         """Test that the "youtube-dl" source tag is added."""
         tags = MusicTags()
+        tags.original = {"purl": ["youtube.com"]}
         tags.resolved = {"date": ["2022-02-02"]}
         tags.add_source_tag()
         self.assertEqual(2, len(tags.resolved))
@@ -803,7 +804,7 @@ class TestMusicTags(unittest.TestCase):
     def test_preserve_original_comment_when_adding_source(self) -> None:
         """Test that source tag doesn't overwrite."""
         tags = MusicTags()
-        tags.original = {"comment": ["test"]}
+        tags.original = {"comment": ["test"], "purl": ["youtube.com"]}
         tags.resolved = {"date": ["2022-02-02"]}
         tags.add_source_tag()
         self.assertEqual(2, len(tags.resolved))

--- a/tests/test_music_tags.py
+++ b/tests/test_music_tags.py
@@ -412,7 +412,7 @@ class TestMusicTags(unittest.TestCase):
     def test_print_resolved(self) -> None:
         """Test that resolved tags can be printed."""
         tags = MusicTags()
-        tags.original = {"artist": ["artist 1"], "title": ["title 1"]}
+        tags.original = {"artist": ["artist 1"], "title": ["title 1"], "producer": ["someone"]}
         tags.resolved = {"artist": ["artist 1"], "title": ["title 2"], "producer": ["[Removed]"]}
         tags.print_resolved(print_all=False)
         captured = self.capsys.readouterr()  # type: ignore
@@ -431,7 +431,7 @@ class TestMusicTags(unittest.TestCase):
             f"  Conductor: {Fore.BLACK}Not found{Fore.RESET}\n"
             f"  Arranger: {Fore.BLACK}Not found{Fore.RESET}\n"
             f"  Author: {Fore.BLACK}Not found{Fore.RESET}\n"
-            f"  Producer: {Fore.RED}[Removed]{Fore.RESET}\n"
+            f"  Producer (Removed): {Fore.RED}someone{Fore.RESET}\n"
             f"  Publisher: {Fore.BLACK}Not found{Fore.RESET}\n"
             f"  Lyricist: {Fore.BLACK}Not found{Fore.RESET}\n\n"
         )
@@ -443,6 +443,7 @@ class TestMusicTags(unittest.TestCase):
         tags.original = {
             "performer:vocals": ["artist 1"],
             "performer:violin": ["artist 1"],
+            "performer:keyboard": ["some guy"],
         }
         tags.resolved = {
             "performer:vocals": ["artist 1"],
@@ -457,7 +458,7 @@ class TestMusicTags(unittest.TestCase):
             f"  - Background Vocals: {Fore.BLACK}Not found{Fore.RESET}\n"
             f"  - Drums: {Fore.BLACK}Not found{Fore.RESET}\n"
             f"  - Percussion: {Fore.BLACK}Not found{Fore.RESET}\n"
-            f"  - Keyboard: {Fore.RED}[Removed]{Fore.RESET}\n"
+            f"  - Keyboard (Removed): {Fore.RED}some guy{Fore.RESET}\n"
             f"  - Piano: {Fore.BLACK}Not found{Fore.RESET}\n"
             f"  - Synthesizer: {Fore.BLACK}Not found{Fore.RESET}\n"
             f"  - Guitar: {Fore.BLACK}Not found{Fore.RESET}\n"
@@ -503,6 +504,7 @@ class TestMusicTags(unittest.TestCase):
             "performer:vocals": ["artist 1"],
             "performer:violin": ["artist 1"],
             "performer:guitar": ["artist 3"],
+            "performer:keyboard": ["the keyboard master"],
         }
         tags.youtube = {
             "performer:guitar": ["artist 4"],
@@ -520,7 +522,7 @@ class TestMusicTags(unittest.TestCase):
             f"  - Background Vocals: {Fore.BLACK}Not found{Fore.RESET}\n"
             f"  - Drums: {Fore.BLACK}Not found{Fore.RESET}\n"
             f"  - Percussion: {Fore.BLACK}Not found{Fore.RESET}\n"
-            f"  - Keyboard: {Fore.RED}[Removed]{Fore.RESET}\n"
+            f"  - Keyboard (Removed): {Fore.RED}the keyboard master{Fore.RESET}\n"
             f"  - Piano: {Fore.BLACK}Not found{Fore.RESET}\n"
             f"  - Synthesizer: {Fore.BLACK}Not found{Fore.RESET}\n"
             f"  - Guitar: {Fore.CYAN}artist 3{Fore.RESET} | {Fore.MAGENTA}artist 4{Fore.RESET}\n"
@@ -565,9 +567,11 @@ class TestMusicTags(unittest.TestCase):
             "performer:vocals": ["artist 1"],
             "performer:violin": ["artist 1"],
             "performer:guitar": ["artist 3"],
+            "performer:keyboard": ["artist 5"],
         }
         tags.youtube = {
             "performer:guitar": ["artist 4"],
+            "performer:keyboard": ["artist 6"],
         }
         tags.resolved = {
             "performer:vocals": ["artist 1"],
@@ -582,7 +586,7 @@ class TestMusicTags(unittest.TestCase):
             f"  - Background Vocals: {Fore.BLACK}Not found{Fore.RESET}\n"
             f"  - Drums: {Fore.BLACK}Not found{Fore.RESET}\n"
             f"  - Percussion: {Fore.BLACK}Not found{Fore.RESET}\n"
-            f"  - Keyboard: {Fore.RED}[Removed]{Fore.RESET}\n"
+            f"  - Keyboard (Removed): {Fore.RED}artist 5{Fore.RESET}\n"
             f"  - Piano: {Fore.BLACK}Not found{Fore.RESET}\n"
             f"  - Synthesizer: {Fore.BLACK}Not found{Fore.RESET}\n"
             f"  - Guitar: {Fore.BLACK}Not found{Fore.RESET}\n"
@@ -654,7 +658,7 @@ class TestMusicTags(unittest.TestCase):
             f"  Conductor: {Fore.BLACK}Not found{Fore.RESET}\n"
             f"  Arranger: {Fore.CYAN}artist 1{Fore.RESET} | {Fore.MAGENTA}artist 2{Fore.RESET}\n"
             f"  Author: {Fore.BLACK}Not found{Fore.RESET}\n"
-            f"  Producer: {Fore.RED}[Removed]{Fore.RESET}\n"
+            f"  Producer (Removed): {Fore.RED}person 1{Fore.RESET}\n"
             f"  Publisher: {Fore.BLACK}Not found{Fore.RESET}\n"
             f"  Lyricist: {Fore.BLACK}Not found{Fore.RESET}\n\n"
         )
@@ -698,7 +702,7 @@ class TestMusicTags(unittest.TestCase):
             f"  Conductor: {Fore.BLACK}Not found{Fore.RESET}\n"
             f"  Arranger: {Fore.BLACK}Not found{Fore.RESET}\n"
             f"  Author: {Fore.BLACK}Not found{Fore.RESET}\n"
-            f"  Producer: {Fore.RED}[Removed]{Fore.RESET}\n"
+            f"  Producer (Removed): {Fore.RED}person 1{Fore.RESET}\n"
             f"  Publisher: {Fore.BLACK}Not found{Fore.RESET}\n"
             f"  Lyricist: {Fore.BLACK}Not found{Fore.RESET}\n\n"
         )


### PR DESCRIPTION
Tags that should be deleted can be named in the configuration, and
specific values, the presence of which in tags will cause the deletion
of said tag, can also be named.

Old hardcoded tags to delete have been removed as it is now in the hands
of the users.
